### PR TITLE
fix: prevent duplicate provider function calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/siderolabs/go-pointer v1.0.1 // indirect
 	github.com/siderolabs/image-factory v0.8.4 // indirect
 	github.com/siderolabs/net v0.4.0 // indirect
-	github.com/siderolabs/omni/client v1.2.0-beta.3.0.20251027150545-a91eabdf1e6a
+	github.com/siderolabs/omni/client v1.2.0-beta.3.0.20251029155136-c2cbf34b02e1
 	github.com/siderolabs/protoenc v0.2.4 // indirect
 	github.com/siderolabs/talos/pkg/machinery v1.12.0-alpha.1.0.20251017073026-8124efb42fd5 // indirect
 	github.com/stoewer/go-strcase v1.3.1 // indirect
@@ -77,5 +77,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/grpc v1.76.0 // indirect
-	gopkg.in/yaml.v3 v3.0.3
+	gopkg.in/yaml.v3 v3.0.3 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/siderolabs/image-factory v0.8.4 h1:fVC85y8fBAnZLxSkA9eHzzH+yf48Gyd7ea
 github.com/siderolabs/image-factory v0.8.4/go.mod h1:CJd8CHVkaggfzHvwP+TXuwe+yyH94rEazf/RBfARrCE=
 github.com/siderolabs/net v0.4.0 h1:1bOgVay/ijPkJz4qct98nHsiB/ysLQU0KLoBC4qLm7I=
 github.com/siderolabs/net v0.4.0/go.mod h1:/ibG+Hm9HU27agp5r9Q3eZicEfjquzNzQNux5uEk0kM=
-github.com/siderolabs/omni/client v1.2.0-beta.3.0.20251027150545-a91eabdf1e6a h1:6sug0fK7ZxhCzRU81nIpkdeZZG7k+5ntMCVFPGn6Tsw=
-github.com/siderolabs/omni/client v1.2.0-beta.3.0.20251027150545-a91eabdf1e6a/go.mod h1:aCNEBiJs+yDlbCv21f75mLsMDg1cqxcd7vaOgP4Yum4=
+github.com/siderolabs/omni/client v1.2.0-beta.3.0.20251029155136-c2cbf34b02e1 h1:d8hRDIijM8Go9irT7SAKOwztz7G7rIa2PDq36m2KNuE=
+github.com/siderolabs/omni/client v1.2.0-beta.3.0.20251029155136-c2cbf34b02e1/go.mod h1:aCNEBiJs+yDlbCv21f75mLsMDg1cqxcd7vaOgP4Yum4=
 github.com/siderolabs/proto-codec v0.1.2 h1:KYrRiCk5wdA2ilZZoW4bWtICCF4y3r28FhmunPa50HE=
 github.com/siderolabs/proto-codec v0.1.2/go.mod h1:TCsjpw732TWuOx4Vd4gYhivPOttEhdPvczLfMQ6Y9Dc=
 github.com/siderolabs/protoenc v0.2.4 h1:D3Fpn2nQSQOhl8ZlAxijZAf7K6F8CM1uZq0afIGsr8Q=


### PR DESCRIPTION
Updated `github.com/siderolabs/omni/client` to include the change in https://github.com/siderolabs/omni/commit/c2cbf34b02e1288cf7d55bc0ed444513fa912d18.

This ensures both `ProvisionSteps` and `Deprovision` are no longer called twice, allowing us to eliminate idempotency logic in the provider should we choose to do so. It also is less confusing to users since they will no longer see logs showing that a function was called right after the function completed successfully.