### PR TITLE
chore: bump version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v0.1.0
+VERSION ?= v0.2.0
 GO_CONTAINER_IMAGE ?= docker.io/golang:1.25.5
 
 # Set this to non-empty when building and pushing a release.


### PR DESCRIPTION
Bumped to next development version.

Closes SSE-25.