### PR TITLE
feat: set providerID via configuration patch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,5 +77,5 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251007200510-49b9836ed3ff // indirect
 	google.golang.org/grpc v1.76.0 // indirect
-	gopkg.in/yaml.v3 v3.0.3 // indirect
+	gopkg.in/yaml.v3 v3.0.3
 )


### PR DESCRIPTION
Added a step that creates a Talos configuration patch to set the `providerID` in the kubelet configuration. This in turn correctly sets `spec.node.providerID` to the instance ID on the newly created instance, which will simplify logic within the Oxide cloud controller manager.