### PR TITLE
build: fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ test:
 		--target builder \
 		--tag $(if $(IMAGE_REGISTRY),$(IMAGE_REGISTRY)/)$(IMAGE_NAME)-builder:$(IMAGE_TAG) \
 		.
-	$(CONTAINER_RUNTIME) run --rm $(IMAGE_NAME)-builder:$(IMAGE_TAG) go test -v ./...
+	$(CONTAINER_RUNTIME) run --rm $(if $(IMAGE_REGISTRY),$(IMAGE_REGISTRY)/)$(IMAGE_NAME)-builder:$(IMAGE_TAG) go test -v ./...
 
 .PHONY: build
 build:


### PR DESCRIPTION
Add image registry to `make test` so the image path matches the full image tag that was built.