### PR TITLE
feat: set default provisioner concurrency to 5

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	ProviderID             string `conf:"default:oxide,help:Provider ID."`
 	ProviderName           string `conf:"default:Oxide,help:Provider name."`
 	ProviderDescription    string `conf:"default:Oxide Omni infrastructure provider.,help:Provider description."`
-	ProvisionerConcurrency uint   `conf:"default:1,help:Number of concurrent provisioner operations."`
+	ProvisionerConcurrency uint   `conf:"default:5,help:Number of concurrent provisioner operations."`
 	OmniEndpoint           string `conf:"required,notzero,help:Omni API endpoint (e.g.; https://omni.example.com)."`
 	OmniServiceAccountKey  string `conf:"required,notzero,mask,help:Omni service account key."`
 }


### PR DESCRIPTION
Set the default provisioner concurrency to 5, meaning the provisioner can now process 5 Omni requests concurrently. This helps us, and others, catch concurrency issues rather than papering over them with the previous setting of 1.