### PR TITLE
feat: updated machine class attributes

### DIFF
--- a/internal/provider/assets/machine-class-schema.json
+++ b/internal/provider/assets/machine-class-schema.json
@@ -93,7 +93,11 @@
   },
   "required": [
     "project",
+    "cpus",
+    "memory",
     "boot_disk_size",
-    "network_interfaces"
+    "network_interfaces",
+    "auto_restart_policy",
+    "cpu_platform"
   ]
 }

--- a/internal/provider/assets/machine-class-schema.json
+++ b/internal/provider/assets/machine-class-schema.json
@@ -5,39 +5,95 @@
       "type": "string",
       "description": "Oxide project where machines will be created."
     },
-    "vcpus": {
+    "ncpus": {
       "type": "integer",
       "description": "Number of vCPUs to assign to the machine.",
-      "default": 2,
+      "default": 1,
       "minimum": 1
     },
     "memory": {
       "type": "integer",
       "description": "Amount of memory to assign to the instance, in gibibytes.",
-      "default": 8
+      "default": 4,
+      "minimum": 1
     },
-    "disk_size": {
+    "boot_disk_size": {
       "type": "integer",
-      "description": "Disk size, in gibibytes.",
-      "default": 10
+      "description": "Boot disk size, in gibibytes.",
+      "default": 10,
+      "minimum": 1
     },
-    "vpc": {
-      "type": "string",
-      "description": "Name of the VPC to use for the machine's network interface.",
-      "default": "default"
+    "data_disks": {
+      "type": "array",
+      "description": "Additional data disks to attach to the machine. Each disk is created blank and attached at instance creation time.",
+      "default": [],
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Backend type for the data disk. 'distributed' creates a Crucible-backed disk; 'local' creates a sled-local disk.",
+            "enum": ["distributed", "local"]
+          },
+          "size": {
+            "type": "integer",
+            "description": "Data disk size, in gibibytes.",
+            "minimum": 1
+          }
+        },
+        "required": ["type", "size"],
+        "additionalProperties": false
+      }
     },
-    "subnet": {
+    "network_interfaces": {
+      "type": "array",
+      "description": "Network interfaces to attach to the machine.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "ip_config": {
+            "type": "string",
+            "description": "IP configuration for the network interface.",
+            "enum": ["v4", "v6", "dual_stack"]
+          },
+          "subnet_name": {
+            "type": "string",
+            "description": "Name of the subnet to use for the network interface."
+          },
+          "vpc_name": {
+            "type": "string",
+            "description": "Name of the VPC to use for the network interface."
+          }
+        },
+        "required": ["ip_config", "subnet_name", "vpc_name"],
+        "additionalProperties": false
+      }
+    },
+    "auto_restart_policy": {
       "type": "string",
-      "description": "Name of the subnet to use for the machine's network interface.",
-      "default": "default"
+      "description": "Auto restart policy for the machine.",
+      "default": "best_effort",
+      "enum": ["never", "best_effort"]
+    },
+    "cpu_platform": {
+      "type": "string",
+      "description": "CPU platform for the machine.",
+      "default": "amd_milan",
+      "enum": ["amd_milan", "amd_turin"]
+    },
+    "anti_affinity_groups": {
+      "type": "array",
+      "description": "Anti-affinity groups to place the machine in.",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": [
     "project",
-    "vcpus",
-    "memory",
-    "disk_size",
-    "vpc",
-    "subnet"
+    "boot_disk_size",
+    "network_interfaces"
   ]
 }

--- a/internal/provider/assets/machine-class-schema.json
+++ b/internal/provider/assets/machine-class-schema.json
@@ -5,7 +5,7 @@
       "type": "string",
       "description": "Oxide project where machines will be created."
     },
-    "ncpus": {
+    "cpus": {
       "type": "integer",
       "description": "Number of vCPUs to assign to the machine.",
       "default": 1,
@@ -23,9 +23,9 @@
       "default": 10,
       "minimum": 1
     },
-    "data_disks": {
+    "disks": {
       "type": "array",
-      "description": "Additional data disks to attach to the machine. Each disk is created blank and attached at instance creation time.",
+      "description": "Additional disks to attach to the machine. Each disk is created blank and attached at instance creation time.",
       "default": [],
       "items": {
         "type": "object",
@@ -37,7 +37,7 @@
           },
           "size": {
             "type": "integer",
-            "description": "Data disk size, in gibibytes.",
+            "description": "Disk size, in gibibytes.",
             "minimum": 1
           }
         },

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,6 +1,12 @@
 package provider
 
-import _ "embed"
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
 
 // ID uniquely identifies the infrastructure provider within Omni. Omni requires
 // each infrastructure provider to have a unique ID, even if it's the same type
@@ -27,10 +33,68 @@ var MachineClassSchema string
 // MachineClass is the type that the JSON schema represented by
 // [MachineClassSchema] will be marshaled to and unmarshaled from.
 type MachineClass struct {
-	Project  string `json:"project"   yaml:"project"`
-	VCPUS    int    `json:"vcpus"     yaml:"vcpus"`
-	Memory   int    `json:"memory"    yaml:"memory"`
-	DiskSize int    `json:"disk_size" yaml:"disk_size"`
-	VPC      string `json:"vpc"       yaml:"vpc"`
-	Subnet   string `json:"subnet"    yaml:"subnet"`
+	Project            oxide.NameOrId                  `json:"project" yaml:"project"`
+	NCPUS              oxide.InstanceCpuCount          `json:"ncpus" yaml:"ncpus"`
+	Memory             oxide.ByteCount                 `json:"memory" yaml:"memory"`
+	BootDiskSize       oxide.ByteCount                 `json:"boot_disk_size" yaml:"boot_disk_size"`
+	DataDisks          []DataDisk                      `json:"data_disks,omitempty" yaml:"data_disks,omitempty"`
+	NetworkInterfaces  []NetworkInterface              `json:"network_interfaces,omitempty" yaml:"network_interfaces,omitempty"`
+	AutoRestartPolicy  oxide.InstanceAutoRestartPolicy `json:"auto_restart_policy,omitempty" yaml:"auto_restart_policy,omitempty"`
+	CPUPlatform        oxide.InstanceCpuPlatform       `json:"cpu_platform,omitempty" yaml:"cpu_platform,omitempty"`
+	AntiAffinityGroups []oxide.NameOrId                `json:"anti_affinity_groups,omitempty" yaml:"anti_affinity_groups,omitempty"`
+}
+
+// Validate ensures the machine class has the required values needed to create
+// an Oxide instance.
+func (mc MachineClass) Validate() error {
+	var errs []error
+
+	if mc.Project == "" {
+		errs = append(errs, errors.New("project is required"))
+	}
+
+	if mc.NCPUS < 1 {
+		errs = append(errs, errors.New("ncpus must be at least 1"))
+	}
+
+	if mc.Memory < 1 {
+		errs = append(errs, errors.New("memory must be at least 1 GiB"))
+	}
+
+	if mc.BootDiskSize < 1 {
+		errs = append(errs, errors.New("boot_disk_size must be at least 1 GiB"))
+	}
+
+	if len(mc.NetworkInterfaces) == 0 {
+		errs = append(errs, errors.New("network_interfaces must contain at least one interface"))
+	}
+
+	for i, disk := range mc.DataDisks {
+		if disk.Size < 1 {
+			errs = append(errs, fmt.Errorf("data_disks[%d].size must be at least 1 GiB", i))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// NetworkInterface describes a network interface to attach to the machine.
+type NetworkInterface struct {
+	// IPConfig is the IP stack configuration for the network interface.
+	IPConfig oxide.PrivateIpConfigType `json:"ip_config" yaml:"ip_config"`
+
+	// SubnetName is the VPC subnet in which to create the interface.
+	SubnetName oxide.Name `json:"subnet_name" yaml:"subnet_name"`
+
+	// VPCName is the VPC in which to create the interface.
+	VPCName oxide.Name `json:"vpc_name" yaml:"vpc_name"`
+}
+
+// DataDisk describes an additional data disk to attach to the machine.
+type DataDisk struct {
+	// Type is the backend type for the data disk.
+	Type oxide.DiskBackendType `json:"type" yaml:"type"`
+
+	// Size is the size of the data disk, in gibibytes.
+	Size oxide.ByteCount `json:"size" yaml:"size"`
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,15 +33,15 @@ var MachineClassSchema string
 // MachineClass is the type that the JSON schema represented by
 // [MachineClassSchema] will be marshaled to and unmarshaled from.
 type MachineClass struct {
-	Project            oxide.NameOrId                  `json:"project" yaml:"project"`
-	NCPUS              oxide.InstanceCpuCount          `json:"ncpus" yaml:"ncpus"`
-	Memory             oxide.ByteCount                 `json:"memory" yaml:"memory"`
-	BootDiskSize       oxide.ByteCount                 `json:"boot_disk_size" yaml:"boot_disk_size"`
-	DataDisks          []DataDisk                      `json:"data_disks,omitempty" yaml:"data_disks,omitempty"`
-	NetworkInterfaces  []NetworkInterface              `json:"network_interfaces,omitempty" yaml:"network_interfaces,omitempty"`
-	AutoRestartPolicy  oxide.InstanceAutoRestartPolicy `json:"auto_restart_policy,omitempty" yaml:"auto_restart_policy,omitempty"`
-	CPUPlatform        oxide.InstanceCpuPlatform       `json:"cpu_platform,omitempty" yaml:"cpu_platform,omitempty"`
-	AntiAffinityGroups []oxide.NameOrId                `json:"anti_affinity_groups,omitempty" yaml:"anti_affinity_groups,omitempty"`
+	Project            oxide.NameOrId                  `json:"project"              yaml:"project"`
+	CPUS               oxide.InstanceCpuCount          `json:"cpus"                 yaml:"cpus"`
+	Memory             oxide.ByteCount                 `json:"memory"               yaml:"memory"`
+	BootDiskSize       oxide.ByteCount                 `json:"boot_disk_size"       yaml:"boot_disk_size"`
+	Disks              []Disk                          `json:"disks"                yaml:"disks"`
+	NetworkInterfaces  []NetworkInterface              `json:"network_interfaces"   yaml:"network_interfaces"`
+	AutoRestartPolicy  oxide.InstanceAutoRestartPolicy `json:"auto_restart_policy"  yaml:"auto_restart_policy"`
+	CPUPlatform        oxide.InstanceCpuPlatform       `json:"cpu_platform"         yaml:"cpu_platform"`
+	AntiAffinityGroups []oxide.NameOrId                `json:"anti_affinity_groups" yaml:"anti_affinity_groups"`
 }
 
 // Validate ensures the machine class has the required values needed to create
@@ -53,8 +53,8 @@ func (mc MachineClass) Validate() error {
 		errs = append(errs, errors.New("project is required"))
 	}
 
-	if mc.NCPUS < 1 {
-		errs = append(errs, errors.New("ncpus must be at least 1"))
+	if mc.CPUS < 1 {
+		errs = append(errs, errors.New("cpus must be at least 1"))
 	}
 
 	if mc.Memory < 1 {
@@ -66,12 +66,43 @@ func (mc MachineClass) Validate() error {
 	}
 
 	if len(mc.NetworkInterfaces) == 0 {
-		errs = append(errs, errors.New("network_interfaces must contain at least one interface"))
+		errs = append(errs, errors.New("network_interfaces is required"))
 	}
 
-	for i, disk := range mc.DataDisks {
+	for i, ni := range mc.NetworkInterfaces {
+		if ni.IPConfig == "" {
+			errs = append(errs, fmt.Errorf("network_interfaces[%d].ip_config is required", i))
+		}
+
+		if ni.IPConfig != oxide.PrivateIpConfigTypeV4 &&
+			ni.IPConfig != oxide.PrivateIpConfigTypeV6 &&
+			ni.IPConfig != oxide.PrivateIpConfigTypeDualStack {
+			errs = append(
+				errs,
+				fmt.Errorf(
+					"network_interfaces[%d].ip_config must be one of [v4, v6, dual_stack]",
+					i,
+				),
+			)
+		}
+
+		if ni.SubnetName == "" {
+			errs = append(errs, fmt.Errorf("network_interfaces[%d].subnet_name is required", i))
+		}
+
+		if ni.VPCName == "" {
+			errs = append(errs, fmt.Errorf("network_interfaces[%d].vpc_name is required", i))
+		}
+	}
+
+	for i, disk := range mc.Disks {
 		if disk.Size < 1 {
-			errs = append(errs, fmt.Errorf("data_disks[%d].size must be at least 1 GiB", i))
+			errs = append(errs, fmt.Errorf("disks[%d].size must be at least 1 GiB", i))
+		}
+
+		if disk.Type != oxide.DiskBackendTypeDistributed &&
+			disk.Type != oxide.DiskBackendTypeLocal {
+			errs = append(errs, fmt.Errorf("disks[%d].type must be one of [distributed, local]", i))
 		}
 	}
 
@@ -90,8 +121,8 @@ type NetworkInterface struct {
 	VPCName oxide.Name `json:"vpc_name" yaml:"vpc_name"`
 }
 
-// DataDisk describes an additional data disk to attach to the machine.
-type DataDisk struct {
+// Disk describes an additional data disk to attach to the machine.
+type Disk struct {
 	// Type is the backend type for the data disk.
 	Type oxide.DiskBackendType `json:"type" yaml:"type"`
 

--- a/internal/provider/provisioner.go
+++ b/internal/provider/provisioner.go
@@ -240,12 +240,24 @@ func (p *Provisioner) ensureInstance(
 	})
 	if err != nil {
 		logger.Error("failed viewing oxide image during instance create", zap.Error(err))
-		return fmt.Errorf("failed viewing oxide image: %w", err)
+		return fmt.Errorf("failed viewing oxide image during instance create: %w", err)
 	}
 
 	logger = logger.With(
 		zap.String("oxide.image.id", image.Id),
 	)
+
+	disks, err := machineClassToOxideDisks(pctx, machineClass)
+	if err != nil {
+		logger.Error("failed parsing machine class into oxide disks", zap.Error(err))
+		return fmt.Errorf("failed parsing machine class into oxide disks: %w", err)
+	}
+
+	networkInterfaces, err := machineClassToOxideNetworkInterfaces(pctx, machineClass)
+	if err != nil {
+		logger.Error("failed parsing machine class into oxide network interfaces", zap.Error(err))
+		return fmt.Errorf("failed parsing machine class into oxide network interfaces: %w", err)
+	}
 
 	params := oxide.InstanceCreateParams{
 		Project: oxide.NameOrId(machineClass.Project),
@@ -282,107 +294,15 @@ func (p *Provisioner) ensureInstance(
 				"Managed by the Oxide Omni infrastructure provider (%s).",
 				ID,
 			),
-			Disks: func() []oxide.InstanceDiskAttachment {
-				attachments := make([]oxide.InstanceDiskAttachment, 0)
-
-				for i, dd := range machineClass.DataDisks {
-					var backend oxide.DiskBackend
-					switch dd.Type {
-					case oxide.DiskBackendTypeLocal:
-						backend = oxide.DiskBackend{Value: &oxide.DiskBackendLocal{}}
-					case oxide.DiskBackendTypeDistributed:
-						backend = oxide.DiskBackend{
-							Value: &oxide.DiskBackendDistributed{
-								DiskSource: oxide.DiskSource{
-									Value: &oxide.DiskSourceBlank{BlockSize: 4096},
-								},
-							},
-						}
-					default:
-						continue
-					}
-
-					attachments = append(attachments, oxide.InstanceDiskAttachment{
-						Value: &oxide.InstanceDiskAttachmentCreate{
-							Description: fmt.Sprintf(
-								"Managed by the Oxide Omni infrastructure provider (%s).",
-								ID,
-							),
-							DiskBackend: backend,
-							Name:        oxide.Name(fmt.Sprintf("data-%02d-%s", i, pctx.GetRequestID())),
-							Size:        dd.Size * 1024 * 1024 * 1024,
-						},
-					})
-				}
-
-				return attachments
-			}(),
-			ExternalIps: []oxide.ExternalIpCreate{},
-			Hostname:    oxide.Hostname(pctx.GetRequestID()),
-			Memory:      machineClass.Memory * 1024 * 1024 * 1024,
-			Name:        oxide.Name(pctx.GetRequestID()),
-			Ncpus:       machineClass.NCPUS,
-			NetworkInterfaces: func() oxide.InstanceNetworkInterfaceAttachment {
-				params := make([]oxide.InstanceNetworkInterfaceCreate, 0)
-
-				for i, val := range machineClass.NetworkInterfaces {
-					var ipConfig oxide.PrivateIpStackCreate
-					switch val.IPConfig {
-					case oxide.PrivateIpConfigTypeV4:
-						ipConfig.Value = oxide.PrivateIpStackCreateV4{
-							Value: oxide.PrivateIpv4StackCreate{
-								Ip: oxide.Ipv4Assignment{
-									Value: oxide.Ipv4AssignmentAuto{},
-								},
-							},
-						}
-					case oxide.PrivateIpConfigTypeV6:
-						ipConfig.Value = oxide.PrivateIpStackCreateV6{
-							Value: oxide.PrivateIpv6StackCreate{
-								Ip: oxide.Ipv6Assignment{
-									Value: oxide.Ipv6AssignmentAuto{},
-								},
-							},
-						}
-					case oxide.PrivateIpConfigTypeDualStack:
-						ipConfig.Value = oxide.PrivateIpStackCreateDualStack{
-							Value: oxide.PrivateIpStackCreateDualStackValue{
-								V4: oxide.PrivateIpv4StackCreate{
-									Ip: oxide.Ipv4Assignment{
-										Value: oxide.Ipv4AssignmentAuto{},
-									},
-								},
-								V6: oxide.PrivateIpv6StackCreate{
-									Ip: oxide.Ipv6Assignment{
-										Value: oxide.Ipv6AssignmentAuto{},
-									},
-								},
-							},
-						}
-					default:
-						continue
-					}
-
-					params = append(params, oxide.InstanceNetworkInterfaceCreate{
-						Description: fmt.Sprintf(
-							"Managed by the Oxide Omni infrastructure provider (%s).",
-							ID,
-						),
-						IpConfig:   ipConfig,
-						Name:       oxide.Name(fmt.Sprintf("ni-%02d-%s", i, pctx.GetRequestID())),
-						SubnetName: val.SubnetName,
-						VpcName:    val.VPCName,
-					})
-				}
-
-				return oxide.InstanceNetworkInterfaceAttachment{
-					Value: oxide.InstanceNetworkInterfaceAttachmentCreate{
-						Params: params,
-					},
-				}
-			}(),
-			SshPublicKeys: []oxide.NameOrId{},
-			Start:         new(true),
+			Disks:             disks,
+			ExternalIps:       []oxide.ExternalIpCreate{},
+			Hostname:          oxide.Hostname(pctx.GetRequestID()),
+			Memory:            machineClass.Memory * 1024 * 1024 * 1024,
+			Name:              oxide.Name(pctx.GetRequestID()),
+			Ncpus:             machineClass.CPUS,
+			NetworkInterfaces: networkInterfaces,
+			SshPublicKeys:     []oxide.NameOrId{},
+			Start:             new(true),
 			UserData: base64.StdEncoding.EncodeToString(
 				[]byte(pctx.ConnectionParams.JoinConfig),
 			),
@@ -457,7 +377,7 @@ func (p *Provisioner) ensureProviderID(
 	if err != nil {
 		logger.Error("failed marshaling providerID patch", zap.Error(err))
 		return fmt.Errorf(
-			"failed marshaling provider id patch: %w", err,
+			"failed marshaling providerID patch: %w", err,
 		)
 	}
 
@@ -592,6 +512,112 @@ func (p *Provisioner) Deprovision(
 	return nil
 }
 
+func machineClassToOxideDisks(
+	pctx provision.Context[*Machine],
+	machineClass MachineClass,
+) ([]oxide.InstanceDiskAttachment, error) {
+	attachments := make([]oxide.InstanceDiskAttachment, 0)
+
+	for i, dd := range machineClass.Disks {
+		var backend oxide.DiskBackend
+		switch dd.Type {
+		case oxide.DiskBackendTypeLocal:
+			backend = oxide.DiskBackend{Value: &oxide.DiskBackendLocal{}}
+		case oxide.DiskBackendTypeDistributed:
+			backend = oxide.DiskBackend{
+				Value: &oxide.DiskBackendDistributed{
+					DiskSource: oxide.DiskSource{
+						Value: &oxide.DiskSourceBlank{BlockSize: 4096},
+					},
+				},
+			}
+		default:
+			return nil, fmt.Errorf("disks[%d].type has invalid value %s", i, dd.Type)
+		}
+
+		attachments = append(attachments, oxide.InstanceDiskAttachment{
+			Value: &oxide.InstanceDiskAttachmentCreate{
+				Description: fmt.Sprintf(
+					"Managed by the Oxide Omni infrastructure provider (%s).",
+					ID,
+				),
+				DiskBackend: backend,
+				Name:        oxide.Name(fmt.Sprintf("data-%02d-%s", i, pctx.GetRequestID())),
+				Size:        dd.Size * 1024 * 1024 * 1024,
+			},
+		})
+	}
+
+	return attachments, nil
+}
+
+func machineClassToOxideNetworkInterfaces(
+	pctx provision.Context[*Machine],
+	machineClass MachineClass,
+) (oxide.InstanceNetworkInterfaceAttachment, error) {
+	params := make([]oxide.InstanceNetworkInterfaceCreate, 0)
+
+	for i, ni := range machineClass.NetworkInterfaces {
+		var ipConfig oxide.PrivateIpStackCreate
+		switch ni.IPConfig {
+		case oxide.PrivateIpConfigTypeV4:
+			ipConfig.Value = oxide.PrivateIpStackCreateV4{
+				Value: oxide.PrivateIpv4StackCreate{
+					Ip: oxide.Ipv4Assignment{
+						Value: oxide.Ipv4AssignmentAuto{},
+					},
+				},
+			}
+		case oxide.PrivateIpConfigTypeV6:
+			ipConfig.Value = oxide.PrivateIpStackCreateV6{
+				Value: oxide.PrivateIpv6StackCreate{
+					Ip: oxide.Ipv6Assignment{
+						Value: oxide.Ipv6AssignmentAuto{},
+					},
+				},
+			}
+		case oxide.PrivateIpConfigTypeDualStack:
+			ipConfig.Value = oxide.PrivateIpStackCreateDualStack{
+				Value: oxide.PrivateIpStackCreateDualStackValue{
+					V4: oxide.PrivateIpv4StackCreate{
+						Ip: oxide.Ipv4Assignment{
+							Value: oxide.Ipv4AssignmentAuto{},
+						},
+					},
+					V6: oxide.PrivateIpv6StackCreate{
+						Ip: oxide.Ipv6Assignment{
+							Value: oxide.Ipv6AssignmentAuto{},
+						},
+					},
+				},
+			}
+		default:
+			return oxide.InstanceNetworkInterfaceAttachment{}, fmt.Errorf(
+				"network_interfaces[%d].ip_config has invalid value %s",
+				i,
+				ni.IPConfig,
+			)
+		}
+
+		params = append(params, oxide.InstanceNetworkInterfaceCreate{
+			Description: fmt.Sprintf(
+				"Managed by the Oxide Omni infrastructure provider (%s).",
+				ID,
+			),
+			IpConfig:   ipConfig,
+			Name:       oxide.Name(fmt.Sprintf("iface-%02d-%s", i, pctx.GetRequestID())),
+			SubnetName: ni.SubnetName,
+			VpcName:    ni.VPCName,
+		})
+	}
+
+	return oxide.InstanceNetworkInterfaceAttachment{
+		Value: oxide.InstanceNetworkInterfaceAttachmentCreate{
+			Params: params,
+		},
+	}, nil
+}
+
 // roundToNearestGibibyte rounds n up to the nearest multiple of 1 GiB.
 func roundToNearestGibibyte(n int64) int64 {
 	const Gibibyte = 1024 * 1024 * 1024
@@ -723,7 +749,7 @@ func downloadImageToTempFile(
 		logger.Error("failed decompressing talos image",
 			zap.Error(err),
 		)
-		return nil, fmt.Errorf("failed decompressing image: %w", err)
+		return nil, fmt.Errorf("failed decompressing talos image: %w", err)
 	}
 
 	if _, err = f.Seek(0, io.SeekStart); err != nil {
@@ -783,7 +809,7 @@ func createOxideImage(
 	})
 	if err != nil {
 		logger.Error("failed creating scratch disk", zap.Error(err))
-		return fmt.Errorf("failed creating disk: %w", err)
+		return fmt.Errorf("failed creating scratch disk: %w", err)
 	}
 
 	defer func() {
@@ -830,7 +856,7 @@ func createOxideImage(
 		r,
 	); err != nil {
 		logger.Error("failed importing bytes to scratch disk", zap.Error(err))
-		return fmt.Errorf("failed importing bytes to disk: %w", err)
+		return fmt.Errorf("failed importing bytes to scratch disk: %w", err)
 	}
 
 	logger.Info("completed bulk import to scratch disk",
@@ -843,7 +869,7 @@ func createOxideImage(
 	})
 	if err != nil {
 		logger.Error("failed viewing scratch snapshot", zap.Error(err))
-		return fmt.Errorf("failed viewing snapshot: %w", err)
+		return fmt.Errorf("failed viewing scratch snapshot: %w", err)
 	}
 
 	image, err := client.ImageCreate(ctx, oxide.ImageCreateParams{
@@ -871,7 +897,7 @@ func createOxideImage(
 		// cleaned up via the deferred deletes above.
 		if !strings.Contains(err.Error(), "409") {
 			logger.Error("failed creating oxide image", zap.Error(err))
-			return fmt.Errorf("failed creating image: %w", err)
+			return fmt.Errorf("failed creating oxide image: %w", err)
 		}
 		logger.Info("oxide image already exists, skipping creation",
 			zap.Duration("duration", time.Since(createStart)),

--- a/internal/provider/provisioner.go
+++ b/internal/provider/provisioner.go
@@ -71,6 +71,11 @@ func machineClassFromContext(
 			"failed unmarshaling provider data: %w", err,
 		)
 	}
+
+	if err := machineClass.Validate(); err != nil {
+		return MachineClass{}, fmt.Errorf("invalid machine class: %w", err)
+	}
+
 	return machineClass, nil
 }
 
@@ -245,8 +250,14 @@ func (p *Provisioner) ensureInstance(
 	params := oxide.InstanceCreateParams{
 		Project: oxide.NameOrId(machineClass.Project),
 		Body: &oxide.InstanceCreate{
-			AntiAffinityGroups: []oxide.NameOrId{},
-			AutoRestartPolicy:  "",
+			AntiAffinityGroups: func() []oxide.NameOrId {
+				var antiAffinityGroups []oxide.NameOrId
+				for _, val := range machineClass.AntiAffinityGroups {
+					antiAffinityGroups = append(antiAffinityGroups, val)
+				}
+				return antiAffinityGroups
+			}(),
+			AutoRestartPolicy: machineClass.AutoRestartPolicy,
 			BootDisk: oxide.InstanceDiskAttachment{
 				Value: &oxide.InstanceDiskAttachmentCreate{
 					Description: fmt.Sprintf(
@@ -262,44 +273,114 @@ func (p *Provisioner) ensureInstance(
 							},
 						},
 					},
-					Name: oxide.Name(pctx.GetRequestID()),
-					Size: oxide.ByteCount(machineClass.DiskSize * 1024 * 1024 * 1024),
+					Name: oxide.Name(fmt.Sprintf("talos-%s", pctx.GetRequestID())),
+					Size: oxide.ByteCount(machineClass.BootDiskSize * 1024 * 1024 * 1024),
 				},
 			},
+			CpuPlatform: machineClass.CPUPlatform,
 			Description: fmt.Sprintf(
 				"Managed by the Oxide Omni infrastructure provider (%s).",
 				ID,
 			),
-			Disks:       []oxide.InstanceDiskAttachment{},
-			ExternalIps: []oxide.ExternalIpCreate{},
-			Hostname:    oxide.Hostname(pctx.GetRequestID()),
-			Memory:      oxide.ByteCount(machineClass.Memory * 1024 * 1024 * 1024),
-			Name:        oxide.Name(pctx.GetRequestID()),
-			Ncpus:       oxide.InstanceCpuCount(machineClass.VCPUS),
-			NetworkInterfaces: oxide.InstanceNetworkInterfaceAttachment{
-				Value: &oxide.InstanceNetworkInterfaceAttachmentCreate{
-					Params: []oxide.InstanceNetworkInterfaceCreate{
-						{
+			Disks: func() []oxide.InstanceDiskAttachment {
+				attachments := make([]oxide.InstanceDiskAttachment, 0)
+
+				for i, dd := range machineClass.DataDisks {
+					var backend oxide.DiskBackend
+					switch dd.Type {
+					case oxide.DiskBackendTypeLocal:
+						backend = oxide.DiskBackend{Value: &oxide.DiskBackendLocal{}}
+					case oxide.DiskBackendTypeDistributed:
+						backend = oxide.DiskBackend{
+							Value: &oxide.DiskBackendDistributed{
+								DiskSource: oxide.DiskSource{
+									Value: &oxide.DiskSourceBlank{BlockSize: 4096},
+								},
+							},
+						}
+					default:
+						continue
+					}
+
+					attachments = append(attachments, oxide.InstanceDiskAttachment{
+						Value: &oxide.InstanceDiskAttachmentCreate{
 							Description: fmt.Sprintf(
 								"Managed by the Oxide Omni infrastructure provider (%s).",
 								ID,
 							),
-							Name:       oxide.Name(pctx.GetRequestID()),
-							VpcName:    oxide.Name(machineClass.VPC),
-							SubnetName: oxide.Name(machineClass.Subnet),
-							IpConfig: oxide.PrivateIpStackCreate{
-								Value: oxide.PrivateIpStackCreateV4{
-									Value: oxide.PrivateIpv4StackCreate{
-										Ip: oxide.Ipv4Assignment{
-											Value: &oxide.Ipv4AssignmentAuto{},
-										},
+							DiskBackend: backend,
+							Name:        oxide.Name(fmt.Sprintf("data-%02d-%s", i, pctx.GetRequestID())),
+							Size:        dd.Size * 1024 * 1024 * 1024,
+						},
+					})
+				}
+
+				return attachments
+			}(),
+			ExternalIps: []oxide.ExternalIpCreate{},
+			Hostname:    oxide.Hostname(pctx.GetRequestID()),
+			Memory:      machineClass.Memory * 1024 * 1024 * 1024,
+			Name:        oxide.Name(pctx.GetRequestID()),
+			Ncpus:       machineClass.NCPUS,
+			NetworkInterfaces: func() oxide.InstanceNetworkInterfaceAttachment {
+				params := make([]oxide.InstanceNetworkInterfaceCreate, 0)
+
+				for i, val := range machineClass.NetworkInterfaces {
+					var ipConfig oxide.PrivateIpStackCreate
+					switch val.IPConfig {
+					case oxide.PrivateIpConfigTypeV4:
+						ipConfig.Value = oxide.PrivateIpStackCreateV4{
+							Value: oxide.PrivateIpv4StackCreate{
+								Ip: oxide.Ipv4Assignment{
+									Value: oxide.Ipv4AssignmentAuto{},
+								},
+							},
+						}
+					case oxide.PrivateIpConfigTypeV6:
+						ipConfig.Value = oxide.PrivateIpStackCreateV6{
+							Value: oxide.PrivateIpv6StackCreate{
+								Ip: oxide.Ipv6Assignment{
+									Value: oxide.Ipv6AssignmentAuto{},
+								},
+							},
+						}
+					case oxide.PrivateIpConfigTypeDualStack:
+						ipConfig.Value = oxide.PrivateIpStackCreateDualStack{
+							Value: oxide.PrivateIpStackCreateDualStackValue{
+								V4: oxide.PrivateIpv4StackCreate{
+									Ip: oxide.Ipv4Assignment{
+										Value: oxide.Ipv4AssignmentAuto{},
+									},
+								},
+								V6: oxide.PrivateIpv6StackCreate{
+									Ip: oxide.Ipv6Assignment{
+										Value: oxide.Ipv6AssignmentAuto{},
 									},
 								},
 							},
-						},
+						}
+					default:
+						continue
+					}
+
+					params = append(params, oxide.InstanceNetworkInterfaceCreate{
+						Description: fmt.Sprintf(
+							"Managed by the Oxide Omni infrastructure provider (%s).",
+							ID,
+						),
+						IpConfig:   ipConfig,
+						Name:       oxide.Name(fmt.Sprintf("ni-%02d-%s", i, pctx.GetRequestID())),
+						SubnetName: val.SubnetName,
+						VpcName:    val.VPCName,
+					})
+				}
+
+				return oxide.InstanceNetworkInterfaceAttachment{
+					Value: oxide.InstanceNetworkInterfaceAttachmentCreate{
+						Params: params,
 					},
-				},
-			},
+				}
+			}(),
 			SshPublicKeys: []oxide.NameOrId{},
 			Start:         new(true),
 			UserData: base64.StdEncoding.EncodeToString(
@@ -434,6 +515,11 @@ func (p *Provisioner) Deprovision(
 		zap.String("oxide.instance.id", instance.Id),
 	)
 
+	disks, err := p.oxideClient.InstanceDiskList(ctx, oxide.InstanceDiskListParams{
+		Project:  oxide.NameOrId(machineClass.Project),
+		Instance: oxide.NameOrId(req.Metadata().ID()),
+	})
+
 	logger.Info("stopping oxide instance")
 
 	if _, err := p.oxideClient.InstanceStop(ctx, oxide.InstanceStopParams{
@@ -458,7 +544,8 @@ func (p *Provisioner) Deprovision(
 		}
 
 		instance, err := p.oxideClient.InstanceView(stopCtx, oxide.InstanceViewParams{
-			Instance: oxide.NameOrId(instance.Id),
+			Project:  oxide.NameOrId(machineClass.Project),
+			Instance: oxide.NameOrId(req.Metadata().ID()),
 		})
 		if err != nil {
 			logger.Error("failed refreshing oxide instance state", zap.Error(err))
@@ -483,29 +570,24 @@ func (p *Provisioner) Deprovision(
 
 	logger.Info("deleted oxide instance")
 
-	if instance.BootDiskId == "" {
-		logger.Info("oxide instance has no boot disk, nothing to delete")
-		return nil
-	}
+	logger.Info("deleting instance disks")
 
-	logger = logger.With(
-		zap.String("oxide.instance.boot_disk_id", instance.BootDiskId),
-	)
-
-	logger.Info("deprovisioning boot disk")
-
-	if err := p.oxideClient.DiskDelete(ctx, oxide.DiskDeleteParams{
-		Disk: oxide.NameOrId(instance.BootDiskId),
-	}); err != nil {
-		if !strings.Contains(err.Error(), "404") {
-			logger.Error("failed deleting oxide boot disk", zap.Error(err))
-			return fmt.Errorf("failed deleting oxide boot disk: %w", err)
+	for _, disk := range disks.Items {
+		if err := p.oxideClient.DiskDelete(ctx, oxide.DiskDeleteParams{
+			Disk: oxide.NameOrId(disk.Id),
+		}); err != nil {
+			logger.Error("failed deleting instance disk",
+				zap.Error(err),
+				zap.String("oxide.instance.disk.id", disk.Id),
+				zap.String("oxide.instance.disk.name", string(disk.Name)),
+			)
 		}
-		logger.Info("oxide boot disk already deleted")
-		return nil
-	}
 
-	logger.Info("deleted oxide boot disk")
+		logger.Info("successfully delete instance disk",
+			zap.String("oxide.instance.disk.id", disk.Id),
+			zap.String("oxide.instance.disk.name", string(disk.Name)),
+		)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Updated the machine class to support the following attributes.

* data_disks
* network_interfaces
* auto_restart_policy
* cpu_platform
* anti_affinity_groups

This gives users more flexibility in how machines can be configured. For example, one can configure two data disks on a worker node and then configure them for the `EPHEMERAL` volume and Longhorn using the following machine patch.

```yaml
---
apiVersion: v1alpha1
kind: VolumeConfig
name: EPHEMERAL
provisioning:
    diskSelector:
        match: disk.bus_path == '/pci0000:00/0000:00:11.0/nvme'
    grow: true
---
apiVersion: v1alpha1
kind: RawVolumeConfig
name: longhorn
provisioning:
    diskSelector:
        match: disk.bus_path == '/pci0000:00/0000:00:12.0/nvme'
    grow: true
    minSize: 1GiB
```