### PR TITLE
fix: ensure deprovision is idempotent

### DIFF
--- a/internal/provider/provisioner.go
+++ b/internal/provider/provisioner.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/oxidecomputer/omni-infra-provider-oxide/internal/provider/spec"
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"github.com/siderolabs/omni/client/pkg/constants"
 	"github.com/siderolabs/omni/client/pkg/infra/provision"
@@ -217,7 +218,7 @@ func (p *Provisioner) ensureInstance(
 			zap.String("oxide.instance.id", instance.Id),
 			zap.String("oxide.instance.run_state", string(instance.RunState)),
 		)
-		return nil
+		return p.recordMachineState(ctx, logger, pctx, machineClass)
 	case !strings.Contains(err.Error(), "404"):
 		logger.Error("failed viewing oxide instance", zap.Error(err))
 		return fmt.Errorf("failed viewing oxide instance: %w", err)
@@ -264,9 +265,11 @@ func (p *Provisioner) ensureInstance(
 		Body: &oxide.InstanceCreate{
 			AntiAffinityGroups: func() []oxide.NameOrId {
 				var antiAffinityGroups []oxide.NameOrId
-				for _, val := range machineClass.AntiAffinityGroups {
-					antiAffinityGroups = append(antiAffinityGroups, val)
-				}
+				antiAffinityGroups = append(
+					antiAffinityGroups,
+					machineClass.AntiAffinityGroups...,
+				)
+
 				return antiAffinityGroups
 			}(),
 			AutoRestartPolicy: machineClass.AutoRestartPolicy,
@@ -319,6 +322,58 @@ func (p *Provisioner) ensureInstance(
 
 	logger.Info("created oxide instance",
 		zap.String("oxide.instance.id", instance.Id),
+	)
+
+	return p.recordMachineState(ctx, logger, pctx, machineClass)
+}
+
+// recordMachineState records the Oxide resources created for a machine. This
+// keeps deprovisioning idempotent even after the instance is deleted and Oxide
+// can no longer list the disks that were attached to it.
+func (p *Provisioner) recordMachineState(
+	ctx context.Context,
+	logger *zap.Logger,
+	pctx provision.Context[*Machine],
+	machineClass MachineClass,
+) error {
+	instance, err := p.oxideClient.InstanceView(ctx, oxide.InstanceViewParams{
+		Project:  machineClass.Project,
+		Instance: oxide.NameOrId(pctx.GetRequestID()),
+	})
+	if err != nil {
+		logger.Error("failed viewing oxide instance", zap.Error(err))
+		return fmt.Errorf("failed viewing oxide instance: %w", err)
+	}
+
+	disks, err := p.oxideClient.InstanceDiskList(ctx, oxide.InstanceDiskListParams{
+		Project:  machineClass.Project,
+		Instance: oxide.NameOrId(pctx.GetRequestID()),
+	})
+	if err != nil {
+		logger.Error("failed listing oxide instance disks", zap.Error(err))
+		return fmt.Errorf("failed listing oxide instance disks: %w", err)
+	}
+
+	state := pctx.State.TypedSpec()
+	state.Value.Project = &spec.Project{
+		Id:   instance.ProjectId,
+		Name: string(machineClass.Project),
+	}
+	state.Value.Instance = &spec.Instance{
+		Id:   instance.Id,
+		Name: string(instance.Name),
+	}
+	state.Value.Disks = make([]*spec.Disk, 0, len(disks.Items))
+
+	for _, disk := range disks.Items {
+		state.Value.Disks = append(state.Value.Disks, &spec.Disk{
+			Id:   disk.Id,
+			Name: string(disk.Name),
+		})
+	}
+
+	logger.Info("recorded oxide machine state",
+		zap.Any("state", state.Value),
 	)
 
 	return nil
@@ -401,115 +456,149 @@ func (p *Provisioner) Deprovision(
 	machine *Machine,
 	req *infra.MachineRequest,
 ) error {
-	var machineClass MachineClass
-	if err := yaml.Unmarshal(
-		[]byte(req.TypedSpec().Value.ProviderData),
-		&machineClass,
-	); err != nil {
-		logger.Error("failed unmarshaling provider data", zap.Error(err))
-		return fmt.Errorf("failed unmarshaling provider data: %w", err)
+	state := machine.TypedSpec()
+
+	// We don't have any state, either because [ProvisionSteps] was cancelled early
+	// or a previous version of this code did not publish any state. Either way,
+	// warn the user and return nil so the provider doesn't retry [Deprovision].
+	if state.Value == nil {
+		logger.Warn("machine provider state is empty")
+		return nil
 	}
 
 	logger = logger.With(
 		zap.String("omni.request.id", req.Metadata().ID()),
-		zap.Any("omni.machine_class", machineClass),
-		zap.String("oxide.instance.name", req.Metadata().ID()),
+		zap.Any("state", state.Value),
 	)
 
-	logger.Info("deprovisioning machine")
+	var errs []error
 
+	if state.Value.Instance != nil && state.Value.Instance.Id != "" {
+		logger.Info("deprovisioning oxide instance",
+			zap.String("oxide.instance.id", state.Value.Instance.Id),
+		)
+
+		if err := p.deprovisionInstance(ctx, state.Value.Instance); err != nil {
+			errs = append(errs, fmt.Errorf("failed deprovisioning instance: %w", err))
+		}
+	} else {
+		logger.Warn("machine provider state does not contain instance, skipping deprovision")
+	}
+
+	disks := make([]*spec.Disk, 0, len(state.Value.Disks))
+	for i, disk := range state.Value.Disks {
+		if disk == nil || disk.Id == "" {
+			logger.Warn("machine provider state is missing disk id",
+				zap.Int("index", i),
+			)
+			continue
+		}
+
+		disks = append(disks, disk)
+	}
+
+	if len(disks) != 0 {
+		logger.Info("deprovisioning oxide disks",
+			zap.Int("oxide.disk.count", len(disks)),
+		)
+
+		if err := p.deprovisionDisks(ctx, disks); err != nil {
+			errs = append(errs, fmt.Errorf("failed deprovisioning disks: %w", err))
+		}
+	} else {
+		logger.Warn("machine provider state does not contain disks, skipping deprovision")
+	}
+
+	return errors.Join(errs...)
+}
+
+func (p *Provisioner) deprovisionInstance(
+	ctx context.Context,
+	instanceSpec *spec.Instance,
+) error {
 	instance, err := p.oxideClient.InstanceView(ctx, oxide.InstanceViewParams{
-		Project:  oxide.NameOrId(machineClass.Project),
-		Instance: oxide.NameOrId(req.Metadata().ID()),
+		Instance: oxide.NameOrId(instanceSpec.Id),
 	})
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
-			logger.Info("oxide instance not found, already deleted")
 			return nil
 		}
-		logger.Error("failed viewing oxide instance", zap.Error(err))
 		return fmt.Errorf("failed viewing oxide instance: %w", err)
 	}
 
-	logger = logger.With(
-		zap.String("oxide.instance.id", instance.Id),
-	)
+	if instance.RunState != oxide.InstanceStateStopped {
+		if _, err := p.oxideClient.InstanceStop(ctx, oxide.InstanceStopParams{
+			Instance: oxide.NameOrId(instanceSpec.Id),
+		}); err != nil {
+			if strings.Contains(err.Error(), "404") {
+				return nil
+			}
 
-	disks, err := p.oxideClient.InstanceDiskList(ctx, oxide.InstanceDiskListParams{
-		Project:  oxide.NameOrId(machineClass.Project),
-		Instance: oxide.NameOrId(req.Metadata().ID()),
-	})
-
-	logger.Info("stopping oxide instance")
-
-	if _, err := p.oxideClient.InstanceStop(ctx, oxide.InstanceStopParams{
-		Instance: oxide.NameOrId(instance.Id),
-	}); err != nil {
-		logger.Error("failed stopping oxide instance", zap.Error(err))
-		return fmt.Errorf("failed stopping oxide instance: %w", err)
-	}
-
-	stopCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-
-	ticker := time.NewTicker(3 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-stopCtx.Done():
-			logger.Error("timed out waiting for instance to stop", zap.Error(stopCtx.Err()))
-			return fmt.Errorf("timed out waiting for instance to stop: %w", stopCtx.Err())
-		case <-ticker.C:
+			return fmt.Errorf("failed stopping oxide instance: %w", err)
 		}
 
-		instance, err := p.oxideClient.InstanceView(stopCtx, oxide.InstanceViewParams{
-			Project:  oxide.NameOrId(machineClass.Project),
-			Instance: oxide.NameOrId(req.Metadata().ID()),
-		})
-		if err != nil {
-			logger.Error("failed refreshing oxide instance state", zap.Error(err))
-			return fmt.Errorf("failed refreshing oxide instance state: %w", err)
-		}
+		stopCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
 
-		if instance.RunState == oxide.InstanceStateStopped {
-			break
-		}
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
 
-		logger.Info("waiting for instance to stop",
-			zap.String("oxide.instance.run_state", string(instance.RunState)),
-		)
+		for {
+			select {
+			case <-stopCtx.Done():
+				return fmt.Errorf("timed out waiting for instance to stop: %w", stopCtx.Err())
+			case <-ticker.C:
+			}
+
+			instance, err := p.oxideClient.InstanceView(stopCtx, oxide.InstanceViewParams{
+				Instance: oxide.NameOrId(instanceSpec.Id),
+			})
+			if err != nil {
+				if strings.Contains(err.Error(), "404") {
+					return nil
+				}
+
+				return fmt.Errorf("failed refreshing oxide instance state: %w", err)
+			}
+
+			if instance.RunState == oxide.InstanceStateStopped {
+				break
+			}
+		}
 	}
 
 	if err := p.oxideClient.InstanceDelete(ctx, oxide.InstanceDeleteParams{
-		Instance: oxide.NameOrId(instance.Id),
+		Instance: oxide.NameOrId(instanceSpec.Id),
 	}); err != nil {
-		logger.Error("failed deleting oxide instance", zap.Error(err))
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
+
 		return fmt.Errorf("failed deleting oxide instance: %w", err)
 	}
 
-	logger.Info("deleted oxide instance")
+	return nil
+}
 
-	logger.Info("deleting instance disks")
+func (p *Provisioner) deprovisionDisks(
+	ctx context.Context,
+	diskSpec []*spec.Disk,
+) error {
+	var errs []error
 
-	for _, disk := range disks.Items {
+	for _, disk := range diskSpec {
 		if err := p.oxideClient.DiskDelete(ctx, oxide.DiskDeleteParams{
 			Disk: oxide.NameOrId(disk.Id),
 		}); err != nil {
-			logger.Error("failed deleting instance disk",
-				zap.Error(err),
-				zap.String("oxide.instance.disk.id", disk.Id),
-				zap.String("oxide.instance.disk.name", string(disk.Name)),
-			)
+			if strings.Contains(err.Error(), "404") {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed deleting oxide disk %s: %w", disk.Id, err))
+			continue
 		}
-
-		logger.Info("successfully delete instance disk",
-			zap.String("oxide.instance.disk.id", disk.Id),
-			zap.String("oxide.instance.disk.name", string(disk.Name)),
-		)
 	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func machineClassToOxideDisks(

--- a/internal/provider/spec/machine.pb.go
+++ b/internal/provider/spec/machine.pb.go
@@ -22,11 +22,14 @@ const (
 )
 
 // Machine is the per-request state the infrastructure provider persists between
-// provisioning steps. It's intentionally empty. Each step is idempotent on
-// its own by querying the Oxide API for the current state of its resources, so
-// there's nothing the provider needs to remember.
+// provisioning steps. It records the Oxide resources created for the machine so
+// deprovisioning can remain idempotent after parent-child relationships are
+// removed from Oxide.
 type Machine struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Project       *Project               `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	Instance      *Instance              `protobuf:"bytes,2,opt,name=instance,proto3" json:"instance,omitempty"`
+	Disks         []*Disk                `protobuf:"bytes,3,rep,name=disks,proto3" json:"disks,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -61,12 +64,204 @@ func (*Machine) Descriptor() ([]byte, []int) {
 	return file_internal_provider_spec_machine_proto_rawDescGZIP(), []int{0}
 }
 
+func (x *Machine) GetProject() *Project {
+	if x != nil {
+		return x.Project
+	}
+	return nil
+}
+
+func (x *Machine) GetInstance() *Instance {
+	if x != nil {
+		return x.Instance
+	}
+	return nil
+}
+
+func (x *Machine) GetDisks() []*Disk {
+	if x != nil {
+		return x.Disks
+	}
+	return nil
+}
+
+// Project identifies the Oxide project the machine was created in.
+type Project struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Project) Reset() {
+	*x = Project{}
+	mi := &file_internal_provider_spec_machine_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Project) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Project) ProtoMessage() {}
+
+func (x *Project) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_provider_spec_machine_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Project.ProtoReflect.Descriptor instead.
+func (*Project) Descriptor() ([]byte, []int) {
+	return file_internal_provider_spec_machine_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Project) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Project) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+// Instance identifies the Oxide instance created for the machine.
+type Instance struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Instance) Reset() {
+	*x = Instance{}
+	mi := &file_internal_provider_spec_machine_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Instance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Instance) ProtoMessage() {}
+
+func (x *Instance) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_provider_spec_machine_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Instance.ProtoReflect.Descriptor instead.
+func (*Instance) Descriptor() ([]byte, []int) {
+	return file_internal_provider_spec_machine_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *Instance) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Instance) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+// Disk identifies an Oxide disk created for the machine.
+type Disk struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Disk) Reset() {
+	*x = Disk{}
+	mi := &file_internal_provider_spec_machine_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Disk) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Disk) ProtoMessage() {}
+
+func (x *Disk) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_provider_spec_machine_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Disk.ProtoReflect.Descriptor instead.
+func (*Disk) Descriptor() ([]byte, []int) {
+	return file_internal_provider_spec_machine_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *Disk) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Disk) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 var File_internal_provider_spec_machine_proto protoreflect.FileDescriptor
 
 const file_internal_provider_spec_machine_proto_rawDesc = "" +
 	"\n" +
-	"$internal/provider/spec/machine.proto\x12\x13oxide.provider.spec\"\t\n" +
-	"\aMachineBKZIgithub.com/oxidecomputer/omni-infra-provider-oxide/internal/provider/specb\x06proto3"
+	"$internal/provider/spec/machine.proto\x12\x13oxide.provider.spec\"\xad\x01\n" +
+	"\aMachine\x126\n" +
+	"\aproject\x18\x01 \x01(\v2\x1c.oxide.provider.spec.ProjectR\aproject\x129\n" +
+	"\binstance\x18\x02 \x01(\v2\x1d.oxide.provider.spec.InstanceR\binstance\x12/\n" +
+	"\x05disks\x18\x03 \x03(\v2\x19.oxide.provider.spec.DiskR\x05disks\"-\n" +
+	"\aProject\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\".\n" +
+	"\bInstance\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"*\n" +
+	"\x04Disk\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04nameBKZIgithub.com/oxidecomputer/omni-infra-provider-oxide/internal/provider/specb\x06proto3"
 
 var (
 	file_internal_provider_spec_machine_proto_rawDescOnce sync.Once
@@ -80,16 +275,22 @@ func file_internal_provider_spec_machine_proto_rawDescGZIP() []byte {
 	return file_internal_provider_spec_machine_proto_rawDescData
 }
 
-var file_internal_provider_spec_machine_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_internal_provider_spec_machine_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_internal_provider_spec_machine_proto_goTypes = []any{
-	(*Machine)(nil), // 0: oxide.provider.spec.Machine
+	(*Machine)(nil),  // 0: oxide.provider.spec.Machine
+	(*Project)(nil),  // 1: oxide.provider.spec.Project
+	(*Instance)(nil), // 2: oxide.provider.spec.Instance
+	(*Disk)(nil),     // 3: oxide.provider.spec.Disk
 }
 var file_internal_provider_spec_machine_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	1, // 0: oxide.provider.spec.Machine.project:type_name -> oxide.provider.spec.Project
+	2, // 1: oxide.provider.spec.Machine.instance:type_name -> oxide.provider.spec.Instance
+	3, // 2: oxide.provider.spec.Machine.disks:type_name -> oxide.provider.spec.Disk
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_internal_provider_spec_machine_proto_init() }
@@ -103,7 +304,7 @@ func file_internal_provider_spec_machine_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_provider_spec_machine_proto_rawDesc), len(file_internal_provider_spec_machine_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   1,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/provider/spec/machine.proto
+++ b/internal/provider/spec/machine.proto
@@ -4,7 +4,29 @@ package oxide.provider.spec;
 option go_package = "github.com/oxidecomputer/omni-infra-provider-oxide/internal/provider/spec";
 
 // Machine is the per-request state the infrastructure provider persists between
-// provisioning steps. It's intentionally empty. Each step is idempotent on
-// its own by querying the Oxide API for the current state of its resources, so
-// there's nothing the provider needs to remember.
-message Machine {}
+// provisioning steps. It records the Oxide resources created for the machine so
+// deprovisioning can remain idempotent after parent-child relationships are
+// removed from Oxide.
+message Machine {
+  Project project = 1;
+  Instance instance = 2;
+  repeated Disk disks = 3;
+}
+
+// Project identifies the Oxide project the machine was created in.
+message Project {
+  string id = 1;
+  string name = 2;
+}
+
+// Instance identifies the Oxide instance created for the machine.
+message Instance {
+  string id = 1;
+  string name = 2;
+}
+
+// Disk identifies an Oxide disk created for the machine.
+message Disk {
+  string id = 1;
+  string name = 2;
+}


### PR DESCRIPTION
Updated the `Deprovision` method to be idempotent by saving the created resources to state and using them to delete the resources.