### PR TITLE
misc: bump to v0.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= v0.4.0
+VERSION ?= v0.5.0
 GO_CONTAINER_IMAGE ?= docker.io/golang:1.26.3
 
 # Set this to non-empty when building and pushing a release.


### PR DESCRIPTION
Bumped the version to v0.5.0, the next development version.

Part of SSE-318.