### PR TITLE
fix(ensure_provider_id): use unique configuration patch name

### DIFF
--- a/internal/provider/provisioner.go
+++ b/internal/provider/provisioner.go
@@ -437,7 +437,8 @@ func (p *Provisioner) ensureProviderID(
 		)
 	}
 
-	if err := pctx.CreateConfigPatch(ctx, "providerID", b); err != nil {
+	patchName := fmt.Sprintf("provider-id-%s", pctx.GetRequestID())
+	if err := pctx.CreateConfigPatch(ctx, patchName, b); err != nil {
 		logger.Error("failed creating providerID config patch", zap.Error(err))
 		return fmt.Errorf(
 			"failed creating providerID config patch: %w", err,


### PR DESCRIPTION
The `ensure_provider_id` step now uses a unique name for the configuration patch, allowing multiple infrastructure providers to run in the same Omni instance.

Resolves SSE-372.