### PR TITLE
fix: validate omni machine request

### DIFF
--- a/internal/provider/provisioner.go
+++ b/internal/provider/provisioner.go
@@ -26,6 +26,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const oxideNameMaxLength = 63
+
 // Ensure [Provisioner] implements the [provision.Provisioner] interface.
 var _ provision.Provisioner[*Machine] = (*Provisioner)(nil)
 
@@ -55,10 +57,113 @@ func NewProvisioner(oxideClient *oxide.Client) *Provisioner {
 // [Machine].
 func (p *Provisioner) ProvisionSteps() []provision.Step[*Machine] {
 	return []provision.Step[*Machine]{
+		provision.NewStep("validate_request", p.validateRequest),
 		provision.NewStep("ensure_image", p.ensureImage),
 		provision.NewStep("ensure_instance", p.ensureInstance),
 		provision.NewStep("ensure_provider_id", p.ensureProviderID),
 	}
+}
+
+// validateRequest validates Omni request values before any Oxide resources are
+// read or created.
+func (p *Provisioner) validateRequest(
+	_ context.Context,
+	_ *zap.Logger,
+	pctx provision.Context[*Machine],
+) error {
+	machineClass, err := machineClassFromContext(pctx)
+	if err != nil {
+		return fmt.Errorf("failed retrieving machine class from context: %w", err)
+	}
+
+	if err := validateRequestIDForOxideNames(
+		pctx.GetRequestID(),
+		machineClass,
+	); err != nil {
+		return fmt.Errorf("invalid machine request ID: %w", err)
+	}
+
+	return nil
+}
+
+func validateRequestIDForOxideNames(
+	requestID string,
+	machineClass MachineClass,
+) error {
+	var errs []error
+
+	if err := validateOxideName(requestID); err != nil {
+		errs = append(errs, fmt.Errorf("request ID %q is invalid: %w", requestID, err))
+	}
+
+	for _, name := range longestDerivedOxideNames(requestID, machineClass) {
+		if len(name) > oxideNameMaxLength {
+			errs = append(errs, fmt.Errorf(
+				"request ID %q is too long: derived Oxide name %q is %d characters, maximum is %d",
+				requestID,
+				name,
+				len(name),
+				oxideNameMaxLength,
+			))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateOxideName(name string) error {
+	switch {
+	case name == "":
+		return errors.New("must not be empty")
+	case len(name) > oxideNameMaxLength:
+		return fmt.Errorf(
+			"is %d characters, maximum is %d",
+			len(name),
+			oxideNameMaxLength,
+		)
+	case name[0] < 'a' || name[0] > 'z':
+		return errors.New("must start with a lowercase ASCII letter")
+	case name[len(name)-1] == '-':
+		return errors.New("must not end with a dash")
+	}
+
+	for i := range len(name) {
+		ch := name[i]
+		if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+			continue
+		}
+
+		return errors.New("must contain only lowercase ASCII letters, digits, or dashes")
+	}
+
+	return nil
+}
+
+func longestDerivedOxideNames(
+	requestID string,
+	machineClass MachineClass,
+) []string {
+	names := make([]string, 0, 2)
+
+	if len(machineClass.Disks) > 0 {
+		lastDisk := len(machineClass.Disks) - 1
+		names = append(names, oxideDiskName(lastDisk, requestID))
+	}
+
+	if len(machineClass.NetworkInterfaces) > 0 {
+		lastInterface := len(machineClass.NetworkInterfaces) - 1
+		names = append(names, oxideNetworkInterfaceName(lastInterface, requestID))
+	}
+
+	return names
+}
+
+func oxideDiskName(index int, requestID string) string {
+	return fmt.Sprintf("disk-%02d-%s", index, requestID)
+}
+
+func oxideNetworkInterfaceName(index int, requestID string) string {
+	return fmt.Sprintf("iface-%02d-%s", index, requestID)
 }
 
 // machineClassFromContext unmarshals the provider data from the
@@ -633,7 +738,7 @@ func machineClassToOxideDisks(
 					ID,
 				),
 				DiskBackend: backend,
-				Name:        oxide.Name(fmt.Sprintf("disk-%02d-%s", i, pctx.GetRequestID())),
+				Name:        oxide.Name(oxideDiskName(i, pctx.GetRequestID())),
 				Size:        dd.Size * 1024 * 1024 * 1024,
 			},
 		})
@@ -696,7 +801,7 @@ func machineClassToOxideNetworkInterfaces(
 				ID,
 			),
 			IpConfig:   ipConfig,
-			Name:       oxide.Name(fmt.Sprintf("iface-%02d-%s", i, pctx.GetRequestID())),
+			Name:       oxide.Name(oxideNetworkInterfaceName(i, pctx.GetRequestID())),
 			SubnetName: ni.SubnetName,
 			VpcName:    ni.VPCName,
 		})

--- a/internal/provider/provisioner_test.go
+++ b/internal/provider/provisioner_test.go
@@ -1,0 +1,115 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProvisionStepsStartWithValidateRequest(t *testing.T) {
+	t.Parallel()
+
+	steps := NewProvisioner(nil).ProvisionSteps()
+	if len(steps) == 0 {
+		t.Fatal("expected provision steps")
+	}
+
+	if got := steps[0].Name(); got != "validate_request" {
+		t.Fatalf("expected first provision step %q, got %q", "validate_request", got)
+	}
+}
+
+func TestValidateRequestIDForOxideNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requestID string
+		mc        MachineClass
+		wantErr   string
+	}{
+		{
+			name:      "valid request ID with longest derived name at limit",
+			requestID: strings.Repeat("a", 54),
+			mc: MachineClass{
+				NetworkInterfaces: make([]NetworkInterface, 1),
+			},
+		},
+		{
+			name:      "empty request ID",
+			requestID: "",
+			wantErr:   "request ID \"\" is invalid: must not be empty",
+		},
+		{
+			name:      "request ID starts with digit",
+			requestID: "1machine",
+			wantErr:   "must start with a lowercase ASCII letter",
+		},
+		{
+			name:      "request ID contains uppercase",
+			requestID: "machine-A",
+			wantErr:   "must contain only lowercase ASCII letters, digits, or dashes",
+		},
+		{
+			name:      "request ID contains underscore",
+			requestID: "machine_a",
+			wantErr:   "must contain only lowercase ASCII letters, digits, or dashes",
+		},
+		{
+			name:      "request ID ends with dash",
+			requestID: "machine-",
+			wantErr:   "must not end with a dash",
+		},
+		{
+			name:      "request ID exceeds direct name limit",
+			requestID: strings.Repeat("a", 64),
+			wantErr:   "maximum is 63",
+		},
+		{
+			name:      "request ID exceeds derived interface name limit",
+			requestID: strings.Repeat("a", 55),
+			mc: MachineClass{
+				NetworkInterfaces: make([]NetworkInterface, 1),
+			},
+			wantErr: "derived Oxide name",
+		},
+		{
+			name:      "request ID exceeds derived disk name limit",
+			requestID: strings.Repeat("a", 56),
+			mc: MachineClass{
+				Disks: make([]Disk, 1),
+			},
+			wantErr: "derived Oxide name",
+		},
+		{
+			name:      "three digit interface index is included",
+			requestID: strings.Repeat("a", 54),
+			mc: MachineClass{
+				NetworkInterfaces: make([]NetworkInterface, 101),
+			},
+			wantErr: "iface-100-",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateRequestIDForOxideNames(tt.requestID, tt.mc)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added a new `validate_request` provisioning step to validate whether the request ID can be used as names for created Oxide resources.

Resolves SSE-390.