### PR TITLE
fix: use request context for image download

### DIFF
--- a/internal/provider/provisioner.go
+++ b/internal/provider/provisioner.go
@@ -47,9 +47,7 @@ type Provisioner struct {
 func NewProvisioner(oxideClient *oxide.Client) *Provisioner {
 	return &Provisioner{
 		oxideClient: oxideClient,
-		httpClient: &http.Client{
-			Timeout: 30 * time.Second,
-		},
+		httpClient:  &http.Client{},
 	}
 }
 


### PR DESCRIPTION
Removed the `Timeout` on the `http.Client` so that the 15 minute context in `ensureImage` is used when downloading the Talos Linux image.

Closes SSE-386.